### PR TITLE
Update .gitignore file to exclude unnecessary files and directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,50 @@
-.idea
-/target/*
+target/
+
 .env
+
+# Compiled class file
+*.class
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+
+# STS #
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+# IntelliJ IDEA #
+.idea
+*.iws
+*.iml
+*.ipr
+
+# NetBeans #
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+
+# VS Code #
+.vscode/


### PR DESCRIPTION
Excluded

- Compiled class files
- BlueJ files
- Mobile Tools for Java
- Package Files
- Virtual Machine crash logs
- Spring Tools Suite files
- IntelliJ IDEA files
- NetBeans files
- VSCode files